### PR TITLE
Guard against possible gesture recognisers sending messages to deallocated objects on the parent table

### DIFF
--- a/MGSwipeTableCell/MGSwipeTableCell.m
+++ b/MGSwipeTableCell/MGSwipeTableCell.m
@@ -421,6 +421,11 @@ static NSMutableSet * singleSwipePerTable;
 
 -(void) dealloc
 {
+	// Remove all references to this object on gesture recognisers on the parentTable
+    for (UIGestureRecognizer *recogniser in [[self parentTable] gestureRecognizers]) {
+        [recogniser removeTarget:self action:NULL];
+    }
+    
     [self hideSwipeOverlayIfNeeded];
 }
 


### PR DESCRIPTION
Fixes an issue where a gesture recogniser can persist on the parent table that points to a deallocated table cell. This was happening sometimes when cells were deleted and the table thought it needed to hide it's swipe buttons.
